### PR TITLE
fix: generate the sitemap by rendering the LP statically

### DIFF
--- a/lp/public/sitemap-0.xml
+++ b/lp/public/sitemap-0.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://galopen.kkweb.io/en</loc><lastmod>2026-08-20T10:06:53.177Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://galopen.kkweb.io/ja</loc><lastmod>2026-08-20T10:06:53.177Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/lp/public/sitemap.xml
+++ b/lp/public/sitemap.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://galopen.kkweb.io/sitemap-0.xml</loc></sitemap>
 </sitemapindex>

--- a/lp/src/app/[locale]/layout.tsx
+++ b/lp/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages, getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { ReactNode } from "react";
 import { routing } from "@/i18n/routing";
 import "./globals.css";
@@ -84,12 +84,12 @@ export default async function RootLayout({
     notFound();
   }
 
-  const messages = await getMessages();
+  setRequestLocale(locale);
 
   return (
     <html lang={locale} suppressHydrationWarning={true}>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <NextIntlClientProvider messages={messages}>{children}</NextIntlClientProvider>
+        <NextIntlClientProvider>{children}</NextIntlClientProvider>
         <Analytics />
       </body>
     </html>

--- a/lp/src/app/[locale]/page.tsx
+++ b/lp/src/app/[locale]/page.tsx
@@ -10,7 +10,7 @@ import {
   Video,
 } from "lucide-react";
 import Image from "next/image";
-import { useTranslations } from "next-intl";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { ReactNode } from "react";
 
 const GITHUB_URL = "https://github.com/piro0919/galopen";
@@ -28,8 +28,14 @@ const FEATURES = [
 
 const SERVICES = ["Zoom", "Google Meet", "Microsoft Teams", "Webex"];
 
-export default function Page(): ReactNode {
-  const t = useTranslations();
+type PageProps = { params: Promise<{ locale: string }> };
+
+export default async function Page({ params }: PageProps): Promise<ReactNode> {
+  const { locale } = await params;
+
+  setRequestLocale(locale);
+
+  const t = await getTranslations();
 
   return (
     <main className="min-h-dvh">


### PR DESCRIPTION
## What

`https://galopen.kkweb.io/sitemap.xml` returned an empty `<sitemapindex>`, so the LP had no sitemap entries.

## Why

`setRequestLocale` was never called, so next-intl kept `/[locale]` on demand-rendered. next-sitemap only lists prerendered pages.

```
before:  ƒ /[locale]                 → 0 URLs
after:   ● /en, ● /ja                → 2 URLs
```

## How

Matches nonja's LP: call `setRequestLocale` in both the layout and the page, and let the request config supply the messages.

## Verified

- `pnpm build` prerenders both locales and next-sitemap writes `sitemap-0.xml`
- `pnpm typecheck` passes
- `pnpm lint` passes